### PR TITLE
docs: expand README and add development guide

### DIFF
--- a/Docs/development.md
+++ b/Docs/development.md
@@ -1,0 +1,27 @@
+# Development Guide
+
+## Prerequisites
+- PHP 8.1+
+- MySQL 5.7+
+- Composer
+- Node.js and npm (optional for asset workflows)
+
+## Setup
+1. Clone the repository and `cd` into the project root.
+2. Copy `Script/includes/config-example.php` to `Script/includes/config.php` and adjust settings.
+3. Install PHP dependencies:
+   ```bash
+   cd Script
+   composer install
+   ```
+4. (Optional) install JavaScript dependencies for asset builds:
+   ```bash
+   npm install
+   ```
+5. Start a local PHP server from the project root:
+   ```bash
+   php -S localhost:8000 -t Script
+   ```
+
+## Running Tests
+This project currently has no automated tests. Contributors are encouraged to add tests using PHPUnit and run them before submitting changes.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-"# Sngine" 
+# Sngine
+
+Sngine is a full-featured PHP social networking platform for building your own social network.
+
+## Overview
+- **Core** located in the `Script/` directory containing the PHP application.
+- **Apps** holds mobile stubs for Android/iOS.
+- **Docs** provides end-user and developer documentation.
+- **Extras** includes optional modules and resources.
+
+## Installation
+1. Install PHP, MySQL, and Composer.
+2. Copy `Script/includes/config-example.php` to `Script/includes/config.php` and update database credentials and site URL.
+3. From the `Script/` directory run `composer install` to pull PHP dependencies.
+4. Start a local server with `php -S localhost:8000 -t Script` and visit `http://localhost:8000`.
+
+## Directory Structure
+```
+Apps/     # Mobile applications
+Docs/     # Project documentation
+Script/   # Core PHP application
+Updates/  # SQL update scripts
+```
+
+## How to Contribute
+1. Fork the repository and create a new branch for your feature or fix.
+2. Make your changes following PHP best practices.
+3. Run available tests or linters before submitting.
+4. Open a pull request describing your changes.
+
+See [Docs/development.md](Docs/development.md) for environment setup and additional guidelines.
+
+## License
+Sngine is distributed under a commercial license. See the product documentation for more details.


### PR DESCRIPTION
## Summary
- Flesh out README with overview, installation, directory layout, and contribution steps
- Add developer guide with environment setup instructions

## Testing
- `composer validate`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c725ad63c8832a8bbf2ee7f12ec37c